### PR TITLE
Update Dockerfile base image to Eclipse Temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-alpine
 
 # 작업 디렉토리 설정
 WORKDIR /app


### PR DESCRIPTION
…penJDK

- Change base image from openjdk:17-jdk-slim to eclipse-temurin:17-jdk-alpine
- Resolve Docker Hub deprecated openjdk image issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 컨테이너 기본 이미지를 업데이트하여 성능과 보안을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->